### PR TITLE
Mobile Popup

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "react-responsive": "^8.1.0",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.0",
+    "sweetalert2": "^10.13.3",
     "tailwindcss": "^1.9.6",
     "web-vitals": "^0.2.4"
   }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,9 +1,34 @@
 import './generated/tailwind.css'
 import { HashRouter, Route, Switch, Redirect } from 'react-router-dom'
+import swal from 'sweetalert2'
 import { ContentCard, ContentWrapper, Header, Navigation } from './components'
-import { pages } from './constants'
+import { pages, TABLET_WIDTH } from './constants'
+
+function getViewportWidth() {
+  // Modern browsers
+  if (window.innerWidth) {
+    return window.innerWidth
+  }
+
+  // IE6
+  if (document.documentElement && document.documentElement.clientWidth) {
+    return document.documentElement.clientWidth
+  }
+
+  // Older versions of IE
+  return document.getElementsByTagName('body')[0].clientWidth
+}
 
 function App() {
+  if (getViewportWidth() <= TABLET_WIDTH) {
+    swal.fire({
+      title: 'Hey there!',
+      html: `<p>I see that you are on a tablet or mobile device!</p><br /><p>The site is not optimized for this yet. You'll have a better experience on a laptop or desktop computer. :)</p>`,
+      icon: 'info',
+      confirmButtonText: 'Got it!'
+    })
+  }
+
   return (
     <HashRouter>
       <div id='app' className='bg-steel text-gold'>

--- a/src/components/Navigation.jsx
+++ b/src/components/Navigation.jsx
@@ -8,7 +8,7 @@ function Navigation() {
     const location = useLocation()
 
     return (
-        <div className='bg-navy text-center text-2xl font-bold'>
+        <div className='bg-navy text-center text-2xl font-bold break-words'>
             <div className='flex flex-col pt-8'>
                 {pages.map(page => {
                     const linkContainerClass = `${linkContainerBaseClass} ${location.pathname === page.path ? selectedClass : ''}`

--- a/src/constants.js
+++ b/src/constants.js
@@ -12,6 +12,9 @@ export const pages = [
     { path: '/gifts', title: 'Gifts', component: Gifts },
 ]
 
+// Screen Sizes
+export const TABLET_WIDTH = 900
+
 // Link Properties
 export const BLANK_TARGET = '_blank'
 export const NEW_TAB = 'noopener noreferrer'

--- a/yarn.lock
+++ b/yarn.lock
@@ -10557,6 +10557,11 @@ svgo@^1.0.0, svgo@^1.2.2:
     unquote "~1.1.1"
     util.promisify "~1.0.0"
 
+sweetalert2@^10.13.3:
+  version "10.13.3"
+  resolved "https://registry.yarnpkg.com/sweetalert2/-/sweetalert2-10.13.3.tgz#04be73d497ae2041dca276f3cb724ec20db4bb56"
+  integrity sha512-kSvTkXvc59+vPf9CfZ/wc/uvFkccxoOMLK1aUibN0mXU4hbYg/NylBTlmfvuUjJQ5SWL3X6s8w7AG5croH8U1w==
+
 symbol-tree@^3.2.4:
   version "3.2.4"
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"


### PR DESCRIPTION
# Summary
Knowing that I'll be releasing this first half of the website with no mobile support, I wanted a way to warn the users that they'll have a much better time on a laptop or desktop computer.

Using [SweetAlert](https://sweetalert2.github.io/), I have made it popup to tell the user exactly that if they reach the website from a tablet or mobile device.

If accepted, this PR will:
- Add [SweetAlert2](https://sweetalert2.github.io/) as  a dependency
- Add styles to make words break in the navigation bar
- Close #27

# How to Test
1. Pull down this branch and `yarn && yarn start`
2. Visit http://localhost:3000
3. No popup should appear, since you're presumably on a computer
4. Shrink your browser so that it's smaller
5. Refresh the page
6. You should see a popup that tells the user that the desktop or laptop experience will be much better
