### PR TITLE
ALL-19: Display User Name on RSVP Form

### DIFF
--- a/src/components/RSVPForm.jsx
+++ b/src/components/RSVPForm.jsx
@@ -87,6 +87,7 @@ function RSVPForm({ guest }) {
 
     return (
         <form id='rsvp-form'>
+            <h4 className="underline pb-4">RSVP Information for {guest.firstName} {guest.lastName}</h4>
             <div className='flex flex-col items-start'>
                 <SelectBox className={fieldClass} label='RSVP' value={rsvp} onChange={toggleRSVP}>
                     <YesNoOptions />


### PR DESCRIPTION
# Summary
If accepted, this PR will:
- Display the user's name on the RSVP form, so that it's clear whose information is being edited

# How to Test
1. `yarn && yarn start`
2. Visit localhost:3000/#/rsvp
3. Search for a valid user
4. Notice that the title now says "RSVP Information for <first name> <last name>" above the form